### PR TITLE
Fix: Error when trying to run the cloud version of the game

### DIFF
--- a/code/GameResources/CarriableInfo.cs
+++ b/code/GameResources/CarriableInfo.cs
@@ -22,7 +22,7 @@ public class CarriableInfo : ItemInfo
 	public string HandsModelPath { get; set; } = "";
 
 	[Category( "WorldModels" )]
-	public CitizenAnimationHelper.HoldTypes HoldType { get; set; } = CitizenAnimationHelper.HoldTypes.None;
+	public CitizenAnimationHelper.HoldTypes HoldType { get; set; } = 0;
 
 	[Title( "World Model" ), Category( "WorldModels" ), ResourceType( "vmdl" )]
 	public string WorldModelPath { get; set; } = "";


### PR DESCRIPTION
For some reason, referencing CitizenAnimationHelper.HoldTypes.None was causing the cloud version of the gamemode to not work.