### PR TITLE
Add MapTimer

### DIFF
--- a/code/GameManager.Convars.cs
+++ b/code/GameManager.Convars.cs
@@ -43,8 +43,13 @@ public partial class GameManager
 	[ConVar.Replicated( "ttt_round_limit", Help = "The maximum amount of rounds that can be played.", Saved = true )]
 	public static int RoundLimit { get; set; } = 6;
 
-	[ConVar.Replicated( "ttt_time_limit_minutes", Help = "The maximum number of minutes per map." )]
-	public static int TimeLimitMinutes { get; set; } = 75;
+	[ConVar.Replicated( "ttt_time_limit_minutes", Help = "The maximum number of minutes per map." ), Change( nameof( UpdateTimeLimitMinutes ) )]
+	public static float TimeLimitMinutes { get; set; } = 75;
+
+	public static void UpdateTimeLimitMinutes( float _, float newValue )
+	{
+		Current.MapTimer = newValue * 60;
+	}
 	#endregion
 
 	#region Minimum Players

--- a/code/GameManager.Convars.cs
+++ b/code/GameManager.Convars.cs
@@ -42,6 +42,9 @@ public partial class GameManager
 
 	[ConVar.Replicated( "ttt_round_limit", Help = "The maximum amount of rounds that can be played.", Saved = true )]
 	public static int RoundLimit { get; set; } = 6;
+
+	[ConVar.Replicated( "ttt_time_limit_minutes", Help = "The maximum number of minutes per map." )]
+	public static int TimeLimitMinutes { get; set; } = 75;
 	#endregion
 
 	#region Minimum Players

--- a/code/GameManager.cs
+++ b/code/GameManager.cs
@@ -20,6 +20,9 @@ public partial class GameManager : Sandbox.GameManager
 
 	public int RTVCount { get; set; }
 
+	[Net]
+	public RealTimeUntil MapTimer { get; set; }
+
 	public GameManager()
 	{
 		Current = this;
@@ -131,6 +134,7 @@ public partial class GameManager : Sandbox.GameManager
 
 	public override void PostLevelLoaded()
 	{
+		MapTimer = 60 * TimeLimitMinutes;
 		ForceStateChange( new WaitingState() );
 	}
 

--- a/code/GameManager.cs
+++ b/code/GameManager.cs
@@ -134,7 +134,7 @@ public partial class GameManager : Sandbox.GameManager
 
 	public override void PostLevelLoaded()
 	{
-		MapTimer = 60 * TimeLimitMinutes;
+		UpdateTimeLimitMinutes( 0, TimeLimitMinutes );
 		ForceStateChange( new WaitingState() );
 	}
 

--- a/code/States/BaseState.cs
+++ b/code/States/BaseState.cs
@@ -60,7 +60,10 @@ public abstract partial class BaseState : BaseNetworkable
 
 	public virtual void OnSecond()
 	{
-		if ( Game.IsServer && TimeLeft )
+		if ( !Game.IsServer )
+			return;
+
+		if ( TimeLeft || GameManager.Current.MapTimer <= 0 )
 			OnTimeUp();
 	}
 

--- a/code/States/BaseState.cs
+++ b/code/States/BaseState.cs
@@ -63,7 +63,7 @@ public abstract partial class BaseState : BaseNetworkable
 		if ( !Game.IsServer )
 			return;
 
-		if ( TimeLeft || GameManager.Current.MapTimer <= 0 )
+		if ( TimeLeft || GameManager.Current.MapTimer )
 			OnTimeUp();
 	}
 

--- a/code/States/BaseState.cs
+++ b/code/States/BaseState.cs
@@ -63,7 +63,7 @@ public abstract partial class BaseState : BaseNetworkable
 		if ( !Game.IsServer )
 			return;
 
-		if ( TimeLeft || GameManager.Current.MapTimer )
+		if ( TimeLeft )
 			OnTimeUp();
 	}
 

--- a/code/States/InProgress.cs
+++ b/code/States/InProgress.cs
@@ -122,7 +122,7 @@ public partial class InProgress : BaseState
 			return;
 		}
 
-		if ( TimeLeft )
+		if ( TimeLeft || GameManager.Current.MapTimer )
 			OnTimeUp();
 	}
 

--- a/code/States/PostRound.cs
+++ b/code/States/PostRound.cs
@@ -61,7 +61,7 @@ public partial class PostRound : BaseState
 	{
 		bool shouldChangeMap;
 
-		shouldChangeMap = GameManager.Current.TotalRoundsPlayed >= GameManager.RoundLimit;
+		shouldChangeMap = GameManager.Current.TotalRoundsPlayed >= GameManager.RoundLimit || GameManager.Current.MapTimer <= 0;
 		shouldChangeMap |= GameManager.Current.RTVCount >= MathF.Round( Game.Clients.Count * GameManager.RTVThreshold );
 
 		GameManager.Current.ChangeState( shouldChangeMap ? new MapSelectionState() : new PreRound() );

--- a/code/UI/Game/TabMenu/Scoreboard/Info/ScoreboardInfo.cs
+++ b/code/UI/Game/TabMenu/Scoreboard/Info/ScoreboardInfo.cs
@@ -8,6 +8,6 @@ public partial class ScoreboardInfo : Panel
 {
 	protected override int BuildHash()
 	{
-		return HashCode.Combine( Game.Clients.Count, GameManager.RoundLimit, GameManager.Current.TotalRoundsPlayed );
+		return HashCode.Combine( Game.Clients.Count, GameManager.RoundLimit, GameManager.Current.TotalRoundsPlayed, GameManager.Current.MapTimer.Relative );
 	}
 }

--- a/code/UI/Game/TabMenu/Scoreboard/Info/ScoreboardInfo.razor
+++ b/code/UI/Game/TabMenu/Scoreboard/Info/ScoreboardInfo.razor
@@ -16,7 +16,9 @@
             @{
                 var roundsRemaining = TTT.GameManager.RoundLimit - TTT.GameManager.Current.TotalRoundsPlayed;
                 var suffix = roundsRemaining == 1 ? "round" : "rounds";
-                <text>@($"Map will change in {roundsRemaining} {suffix}")</text>
+                var mapTimeLeft = System.TimeSpan.FromSeconds((TTT.GameManager.Current.MapTimer.Relative).Clamp(0,
+                float.MaxValue)).ToString(@"hh\:mm\:ss");
+                <text>@($"Map will change in {roundsRemaining} {suffix} or in {mapTimeLeft}")</text>
             }
         </text>
     </div>


### PR DESCRIPTION
Closes:https://github.com/CigarLounge/sbox-TTT/issues/299

Right now the map timer will tick down no matter what and is only checked against during the `InProgress` state. This means a case like so will happen: server is empty, map never changes but the timer is out, 2 players join and the map will change after the first round they play. Open to feedback. I still haven't checked how vanilla handles it.