### PR TITLE
Fea: Make hands behave more like vanilla Magneto Stick

### DIFF
--- a/code/Items/Equipment/Hands/GrabbableProp.cs
+++ b/code/Items/Equipment/Hands/GrabbableProp.cs
@@ -42,7 +42,7 @@ public class GrabbableProp : IGrabbable
 			GrabbedEntity = null;
 		}
 
-		if ( !GrabbedEntity.IsValid() || !_owner.IsValid() )
+		if ( !GrabbedEntity.IsValid() || !_owner.IsValid() || GrabbedEntity.IsStoodOnByPlayer() )
 			Drop();
 	}
 

--- a/code/Items/Equipment/Hands/GrabbableProp.cs
+++ b/code/Items/Equipment/Hands/GrabbableProp.cs
@@ -1,4 +1,5 @@
 using Sandbox;
+using Sandbox.Physics;
 
 namespace TTT;
 
@@ -12,8 +13,9 @@ public class GrabbableProp : IGrabbable
 	private readonly Player _owner;
 	private bool _isThrowing = false;
 	private readonly bool _isInteractable = false;
+	private PhysicsJoint _weld;
 
-	public GrabbableProp( Player owner, Entity grabPoint, ModelEntity grabbedEntity )
+	public GrabbableProp( Player owner, ModelEntity grabPoint, ModelEntity grabbedEntity, int bone )
 	{
 		_owner = owner;
 
@@ -26,7 +28,7 @@ public class GrabbableProp : IGrabbable
 		GrabbedEntity = grabbedEntity;
 		GrabbedEntity.EnableTouch = false;
 		GrabbedEntity.EnableHideInFirstPerson = false;
-		GrabbedEntity.SetParent( grabPoint, Hands.MiddleHandsAttachment, new Transform( Vector3.Zero ) );
+		_weld = grabPoint.GmodWeld( grabbedEntity, bone );
 	}
 
 	public void Update( Player player )
@@ -58,7 +60,8 @@ public class GrabbableProp : IGrabbable
 			grabbedEntity.LastAttacker = _owner;
 			grabbedEntity.EnableHideInFirstPerson = true;
 			grabbedEntity.EnableTouch = true;
-			grabbedEntity.SetParent( null );
+			_weld.Remove();
+			_weld = null;
 
 			if ( grabbedEntity is Carriable carriable )
 				carriable.OnCarryDrop( _owner );

--- a/code/Items/Equipment/Hands/Hands.cs
+++ b/code/Items/Equipment/Hands/Hands.cs
@@ -110,7 +110,7 @@ public partial class Hands : Carriable
 			return;
 
 		// Cannot pickup items held by other players.
-		if ( trace.Entity.Parent.IsValid() )
+		if ( trace.Entity.Owner.IsValid() )
 			return;
 
 		switch ( trace.Entity )

--- a/code/Items/Equipment/Hands/Hands.cs
+++ b/code/Items/Equipment/Hands/Hands.cs
@@ -25,7 +25,7 @@ public partial class Hands : Carriable
 	public override string PrimaryAttackHint => !CurrentPrimaryHint.IsNullOrEmpty() ? CurrentPrimaryHint : "Pickup";
 	public override string SecondaryAttackHint => !CurrentSecondaryHint.IsNullOrEmpty() ? CurrentSecondaryHint : "Push";
 
-	public Entity GrabPoint { get; private set; }
+	public ModelEntity GrabPoint { get; private set; }
 	public const string MiddleHandsAttachment = "middle_of_both_hands";
 
 	private bool IsHoldingEntity => _grabbedEntity is not null && _grabbedEntity.IsHolding;
@@ -55,6 +55,9 @@ public partial class Hands : Carriable
 			else
 				PushEntity();
 		}
+
+		GrabPoint.Position = Owner.EyePosition + Owner.EyeRotation.Forward * 70f;
+		GrabPoint.Rotation = Owner.EyeRotation;
 
 		if ( _grabbedEntity is null )
 			return;
@@ -116,11 +119,11 @@ public partial class Hands : Carriable
 				_grabbedEntity = new GrabbableCorpse( Owner, corpse );
 				break;
 			case Carriable: // Ignore any size requirements, any weapon can be picked up.
-				_grabbedEntity = new GrabbableProp( Owner, GrabPoint, trace.Entity as ModelEntity );
+				_grabbedEntity = new GrabbableProp( Owner, GrabPoint, trace.Entity as ModelEntity, trace.Bone );
 				break;
 			case ModelEntity model:
 				if ( CanPickup( model ) )
-					_grabbedEntity = new GrabbableProp( Owner, GrabPoint, model );
+					_grabbedEntity = new GrabbableProp( Owner, GrabPoint, model, trace.Bone );
 				break;
 		}
 	}
@@ -132,9 +135,13 @@ public partial class Hands : Carriable
 		if ( !Game.IsServer )
 			return;
 
-		GrabPoint = new ModelEntity( "models/hands/grabpoint.vmdl" );
-		GrabPoint.EnableHideInFirstPerson = false;
-		GrabPoint.SetParent( player, MiddleHandsAttachment, new Transform( Vector3.Zero ) );
+		GrabPoint = new ModelEntity( "models/rust_props/small_junk/can.vmdl" );
+		GrabPoint.SetupPhysicsFromModel( PhysicsMotionType.Dynamic );
+		GrabPoint.PhysicsBody.Mass = 200f;
+		GrabPoint.PhysicsBody.GravityEnabled = false;
+		GrabPoint.PhysicsBody.MotionEnabled = false;
+		GrabPoint.EnableAllCollisions = false;
+		GrabPoint.EnableDrawing = false;
 	}
 
 	public override void OnCarryDrop( Player player )

--- a/code/Items/Equipment/Hands/Hands.cs
+++ b/code/Items/Equipment/Hands/Hands.cs
@@ -184,7 +184,9 @@ public partial class Hands : Carriable
 			return false;
 
 		var size = entity.CollisionBounds.Size;
-		return size.x < _maxPickupSize.x && size.y < _maxPickupSize.y && size.y < _maxPickupSize.z;
+		var canPickupSize = size.x < _maxPickupSize.x && size.y < _maxPickupSize.y && size.y < _maxPickupSize.z;
+
+		return canPickupSize && !entity.IsStoodOnByPlayer();
 	}
 
 	[Event.Entity.PreCleanup]

--- a/code/Items/Equipment/Hands/IgnoreDamage.cs
+++ b/code/Items/Equipment/Hands/IgnoreDamage.cs
@@ -26,16 +26,4 @@ public partial class IgnoreDamage : EntityComponent<ModelEntity>
 
 		_entity.Tags.Remove( DamageTags.IgnoreDamage );
 	}
-
-	[Event.Tick.Server]
-	private void OnServerTick()
-	{
-		if ( !_entity.IsValid() )
-			return;
-
-		// Once it no longer clips with any other entity remove the component.
-		// FindInBox includes the entity itself. therefore the Count() == 1.
-		if ( Sandbox.Entity.FindInBox( _entity.CollisionBounds + _entity.Position ).Count() == 1 )
-			_entity.Components.RemoveAny<IgnoreDamage>();
-	}
 }

--- a/code/Player/Movement/WalkController.BBox.cs
+++ b/code/Player/Movement/WalkController.BBox.cs
@@ -38,11 +38,15 @@ public partial class WalkController
 			maxs = maxs.WithZ( maxs.z - liftFeet );
 		}
 
-		var tr = Trace.Ray( start + TraceOffset, end + TraceOffset )
+		var trace = Trace.Ray( start + TraceOffset, end + TraceOffset )
 					.Size( mins, maxs )
 					.WithAnyTags( "solid", "playerclip", "passbullets", "player" )
-					.Ignore( Player )
-					.Run();
+					.Ignore( Player );
+
+		if ( Player.HeldProp != null )
+			trace = trace.Ignore( Player.HeldProp );
+
+		var tr = trace.Run();
 
 		tr.EndPosition -= TraceOffset;
 		return tr;

--- a/code/Player/Movement/WalkController.cs
+++ b/code/Player/Movement/WalkController.cs
@@ -167,7 +167,12 @@ public partial class WalkController : BaseNetworkable
 	private void StepMove()
 	{
 		var mover = new MoveHelper( Player.Position, Player.Velocity );
-		mover.Trace = mover.Trace.Size( _mins, _maxs ).Ignore( Player );
+		mover.Trace = mover.Trace.Size( _mins, _maxs )
+			.Ignore( Player );
+
+		if ( Player.HeldProp != null )
+			mover.Trace = mover.Trace.Ignore( Player.HeldProp );
+
 		mover.MaxStandableAngle = GroundAngle;
 
 		mover.TryMoveWithStep( Time.Delta, StepSize );
@@ -179,7 +184,12 @@ public partial class WalkController : BaseNetworkable
 	private void Move()
 	{
 		var mover = new MoveHelper( Player.Position, Player.Velocity );
-		mover.Trace = mover.Trace.Size( _mins, _maxs ).Ignore( Player );
+		mover.Trace = mover.Trace.Size( _mins, _maxs )
+			.Ignore( Player );
+
+		if ( Player.HeldProp != null )
+			mover.Trace = mover.Trace.Ignore( Player.HeldProp );
+
 		mover.MaxStandableAngle = GroundAngle;
 
 		mover.TryMove( Time.Delta );

--- a/code/Player/Movement/WalkController.cs
+++ b/code/Player/Movement/WalkController.cs
@@ -40,7 +40,7 @@ public partial class WalkController : BaseNetworkable
 
 	protected Vector3 GroundNormal { get; set; }
 
-	private const float FallDamageThreshold = 650f;
+	public const float FallDamageThreshold = 650f;
 	private const float FallDamageScale = 0.33f;
 	private Vector3 _lastVelocity;
 	private Vector3 _lastBaseVelocity;

--- a/code/Player/Player.Damage.cs
+++ b/code/Player/Player.Damage.cs
@@ -158,8 +158,13 @@ public partial class Player
 		if ( !IsAlive )
 			return;
 
-		if ( info.Attacker is Prop && info.Attacker.Tags.Has( DamageTags.IgnoreDamage ) )
-			return;
+		if ( info.Attacker is Prop )
+		{
+			if ( info.Attacker.Tags.Has( DamageTags.IgnoreDamage ) )
+				return;
+
+			info.Damage *= .25f;
+		}
 
 		if ( info.Attacker is Player attacker && attacker != this )
 		{

--- a/code/Player/Player.cs
+++ b/code/Player/Player.cs
@@ -83,6 +83,10 @@ public partial class Player : AnimatedEntity
 		var preMomentum = eventData.Other.PreVelocity * eventData.Other.PhysicsShape.Body.Mass;
 		var postMomentum = eventData.Other.PostVelocity * eventData.Other.PhysicsShape.Body.Mass;
 		var extraVelocity = (preMomentum - postMomentum) / PhysicsBody.Mass;
+
+		if ( GroundEntity != null )
+			extraVelocity = extraVelocity.WithZ( float.Max( 0f, extraVelocity.z ) );
+
 		if ( !extraVelocity.IsNaN )
 			Velocity += extraVelocity;
 	}
@@ -374,7 +378,7 @@ public partial class Player : AnimatedEntity
 	public void CreateHull()
 	{
 		SetupPhysicsFromAABB( PhysicsMotionType.Keyframed, new Vector3( -16, -16, 0 ), new Vector3( 16, 16, 72 ) );
-		PhysicsBody.Mass = 85;
+		PhysicsBody.Mass = 300;
 		EnableHitboxes = true;
 	}
 

--- a/code/Player/Player.cs
+++ b/code/Player/Player.cs
@@ -57,6 +57,9 @@ public partial class Player : AnimatedEntity
 	[Net]
 	public int Score { get; set; }
 
+	[Net]
+	public ModelEntity HeldProp { get; set; }
+
 	/// <summary>
 	/// The score gained during a single round. This gets added to the actual score
 	/// at the end of a round.
@@ -73,6 +76,15 @@ public partial class Player : AnimatedEntity
 
 		ClothingContainer.LoadFromClient( client );
 		_avatarClothes = new( ClothingContainer.Clothing );
+	}
+
+	protected override void OnPhysicsCollision( CollisionEventData eventData )
+	{
+		var preMomentum = eventData.Other.PreVelocity * eventData.Other.PhysicsShape.Body.Mass;
+		var postMomentum = eventData.Other.PostVelocity * eventData.Other.PhysicsShape.Body.Mass;
+		var extraVelocity = (preMomentum - postMomentum) / PhysicsBody.Mass;
+		if ( !extraVelocity.IsNaN )
+			Velocity += extraVelocity;
 	}
 
 	public Player()
@@ -362,6 +374,7 @@ public partial class Player : AnimatedEntity
 	public void CreateHull()
 	{
 		SetupPhysicsFromAABB( PhysicsMotionType.Keyframed, new Vector3( -16, -16, 0 ), new Vector3( 16, 16, 72 ) );
+		PhysicsBody.Mass = 85;
 		EnableHitboxes = true;
 	}
 

--- a/code/Player/Player.cs
+++ b/code/Player/Player.cs
@@ -84,8 +84,12 @@ public partial class Player : AnimatedEntity
 		var postMomentum = eventData.Other.PostVelocity * eventData.Other.PhysicsShape.Body.Mass;
 		var extraVelocity = (preMomentum - postMomentum) / PhysicsBody.Mass;
 
+		// If the player is grounded, don't give them downward velocity
+		// Otherwise, don't drop their downward velocity below the fall damage threshold
 		if ( GroundEntity != null )
 			extraVelocity = extraVelocity.WithZ( float.Max( 0f, extraVelocity.z ) );
+		else if ( Velocity.z + extraVelocity.z < -WalkController.FallDamageThreshold )
+			extraVelocity = extraVelocity.WithZ( float.Min( 0f, -WalkController.FallDamageThreshold - Velocity.z ) );
 
 		if ( !extraVelocity.IsNaN )
 			Velocity += extraVelocity;

--- a/code/Util/ModelEntityExtensions.cs
+++ b/code/Util/ModelEntityExtensions.cs
@@ -1,0 +1,28 @@
+using Sandbox;
+using Sandbox.Physics;
+
+namespace TTT;
+
+public static class ModelEntityExtensions
+{
+	public static PhysicsJoint GmodWeld( this ModelEntity a, ModelEntity b, int bBone )
+	{
+		var aP = new PhysicsPoint( a.PhysicsBody );
+		bBone = int.Clamp( bBone, 0, 1 );
+		var bTransform = b.GetBoneTransform( bBone );
+
+		var bP = new PhysicsPoint( b.PhysicsBody, b.Transform.ToLocal( bTransform ).Position, b.Rotation.Inverse * a.Rotation );
+		var weld = PhysicsJoint.CreateFixed( aP, bP );
+		weld.SpringLinear = new PhysicsSpring
+		{
+			Damping = 5f,
+			Frequency = 104.5f,
+		};
+		weld.SpringAngular = new PhysicsSpring
+		{
+			Damping = 10f,
+			Frequency = 150f,
+		};
+		return weld;
+	}
+}

--- a/code/Util/ModelEntityExtensions.cs
+++ b/code/Util/ModelEntityExtensions.cs
@@ -26,4 +26,22 @@ public static class ModelEntityExtensions
 		weld.Strength = 350000f;
 		return weld;
 	}
+
+
+	public static bool IsStoodOnByPlayer( this ModelEntity ent )
+	{
+		if ( !ent.IsValid() )
+			return false;
+
+		foreach ( var client in Game.Clients )
+		{
+			if ( client.Pawn is not Player player || !player.IsAlive )
+				continue;
+
+			if ( player.GroundEntity == ent )
+				return true;
+		}
+
+		return false;
+	}
 }

--- a/code/Util/ModelEntityExtensions.cs
+++ b/code/Util/ModelEntityExtensions.cs
@@ -23,6 +23,7 @@ public static class ModelEntityExtensions
 			Damping = 10f,
 			Frequency = 150f,
 		};
+		weld.Strength = 350000f;
 		return weld;
 	}
 }


### PR DESCRIPTION
I changed the Hands to use a FixedJoint with custom PhysicsSprings instead of parenting to get the elastic effect of the vanilla Magneto Stick. I also made the game reduce prop damage by 75% (like in vanilla), which made it pretty hard to instakill someone with one of the chairs in the skyscraper cafeteria. You'd probably have better luck with heavier props, though. Also, sometimes a prop hits someone several times in one go and does massive damage, which mimics the inconsistency of vanilla propkilling. 