### PR TITLE
Add a more debug friendly bot

### DIFF
--- a/code/Other/DebugBot.cs
+++ b/code/Other/DebugBot.cs
@@ -17,18 +17,11 @@ public partial class DebugBot : Bot
 	/// </summary>
 	public Player Target;
 
-	public static bool Aimbot;
 	public static bool Mimic;
 	public static bool Wander;
 
 	[ConVar.Replicated( "bot_debug" )]
 	public static bool DrawDebug { get; set; }
-
-	[ConCmd.Admin( "bot_aimbot", Help = "Locks the bot's aim to the player." )]
-	public static void ToggleBotAimbot()
-	{
-		Aimbot = !Aimbot;
-	}
 
 	[ConCmd.Admin( "bot_mimic", Help = "Makes the bot mimic the host client's inputs." )]
 	public static void ToggleMimicHost()
@@ -49,7 +42,6 @@ public partial class DebugBot : Bot
 	{
 		Wander = false;
 		Mimic = false;
-		Aimbot = false;
 	}
 
 	[ConCmd.Admin( "bot_kill", Help = "Kills bot by name if provided, else kills all bots." )]

--- a/code/Other/DebugBot.cs
+++ b/code/Other/DebugBot.cs
@@ -15,7 +15,7 @@ public partial class DebugBot : Bot
 	/// <summary>
 	/// The host Player who spawned this bot.
 	/// </summary>
-	public Player Target;
+	public Player Spawner;
 
 	public static bool Mimic;
 	public static bool Wander;
@@ -49,9 +49,9 @@ public partial class DebugBot : Bot
 	{
 		if ( string.IsNullOrEmpty( name ) )
 		{
-			foreach ( var b in All.ToArray() )
+			foreach ( var bot in Bot.All.ToArray() )
 			{
-				if ( b.Client.Pawn is Entity ent )
+				if ( bot.Client.Pawn is Entity ent )
 					ent.OnKilled();
 			}
 
@@ -59,9 +59,9 @@ public partial class DebugBot : Bot
 		}
 
 		var nameLower = name.ToLower();
-		foreach ( var b in All.ToArray() )
+		foreach ( var bot in Bot.All.ToArray() )
 		{
-			if ( b.Client.Name.ToLower() == nameLower && b.Client.Pawn is Entity ent )
+			if ( bot.Client.Name.ToLower() == nameLower && bot.Client.Pawn is Entity ent )
 				ent.OnKilled();
 		}
 	}
@@ -69,20 +69,20 @@ public partial class DebugBot : Bot
 	[ConCmd.Admin( "bot_kick", Help = "Kicks all bots." )]
 	public static void BotKick()
 	{
-		foreach ( var b in All.ToArray() )
-			b.Client.Kick();
+		foreach ( var bot in Bot.All.ToArray() )
+			bot.Client.Kick();
 	}
 
 	[ConCmd.Admin( "bot_add" )]
 	public static void AddBot()
 	{
 		var pawn = ConsoleSystem.Caller.Pawn;
-		if ( pawn is not Player ply )
+		if ( pawn is not Player player )
 			return;
 
-		var b = new DebugBot();
-		b.Target = ply;
-		b.Pawn = b.Client.Pawn as Player;
+		var bot = new DebugBot();
+		bot.Spawner = player;
+		bot.Pawn = bot.Client.Pawn as Player;
 	}
 
 	public override void BuildInput()
@@ -100,11 +100,11 @@ public partial class DebugBot : Bot
 
 		if ( Mimic )
 		{
-			Input.CopyLastInput( Target.Client );
+			Input.CopyLastInput( Spawner.Client );
 			foreach ( var item in from p in GlobalGameNamespace.TypeLibrary.GetPropertyDescriptions( Client.Pawn )
 								  where p.HasAttribute<ClientInputAttribute>()
 								  select p )
-				item.SetValue( Client.Pawn, item.GetValue( Target ) );
+				item.SetValue( Client.Pawn, item.GetValue( Spawner ) );
 		}
 	}
 }

--- a/code/Other/DebugBot.cs
+++ b/code/Other/DebugBot.cs
@@ -23,14 +23,14 @@ public partial class DebugBot : Bot
 	[ConVar.Replicated( "bot_debug" )]
 	public static bool DrawDebug { get; set; }
 
-	[ConCmd.Admin( "bot_mimic", Help = "Makes the bot mimic the host client's inputs." )]
+	[ConCmd.Admin( "bot_mimic", Help = "Make bots mimic your inputs." )]
 	public static void ToggleMimicHost()
 	{
 		Mimic = !Mimic;
 		Wander = false;
 	}
 
-	[ConCmd.Admin( "bot_wander", Help = "Makes the bot randomly press move buttons." )]
+	[ConCmd.Admin( "bot_wander", Help = "Make bots randomly press move buttons." )]
 	public static void ToggleWander()
 	{
 		Wander = !Wander;
@@ -44,7 +44,7 @@ public partial class DebugBot : Bot
 		Mimic = false;
 	}
 
-	[ConCmd.Admin( "bot_kill", Help = "Kills bot by name if provided, else kills all bots." )]
+	[ConCmd.Admin( "bot_kill", Help = "Kills a bot by name if provided, else kills all bots." )]
 	public static void BotKill( string name = "" )
 	{
 		if ( string.IsNullOrEmpty( name ) )

--- a/code/Other/DebugBot.cs
+++ b/code/Other/DebugBot.cs
@@ -18,7 +18,7 @@ public partial class DebugBot : Bot
 	public Player Target;
 
 	public static bool Aimbot;
-	public static bool MimicHost;
+	public static bool Mimic;
 	public static bool Wander;
 
 	[ConVar.Replicated( "bot_debug" )]
@@ -33,7 +33,7 @@ public partial class DebugBot : Bot
 	[ConCmd.Admin( "bot_mimic", Help = "Makes the bot mimic the host client's inputs." )]
 	public static void ToggleMimicHost()
 	{
-		MimicHost = !MimicHost;
+		Mimic = !Mimic;
 		Wander = false;
 	}
 
@@ -41,14 +41,14 @@ public partial class DebugBot : Bot
 	public static void ToggleWander()
 	{
 		Wander = !Wander;
-		MimicHost = false;
+		Mimic = false;
 	}
 
 	[ConCmd.Admin( "bot_reset", Help = "Resets bot to default settings." )]
 	public static void BotReset()
 	{
 		Wander = false;
-		MimicHost = false;
+		Mimic = false;
 		Aimbot = false;
 	}
 
@@ -106,7 +106,7 @@ public partial class DebugBot : Bot
 		if ( Wander )
 			Pawn.InputDirection = Vector3.Random * 2f;
 
-		if ( MimicHost )
+		if ( Mimic )
 		{
 			Input.CopyLastInput( Target.Client );
 			foreach ( var item in from p in GlobalGameNamespace.TypeLibrary.GetPropertyDescriptions( Client.Pawn )

--- a/code/Other/DebugBot.cs
+++ b/code/Other/DebugBot.cs
@@ -45,7 +45,7 @@ public partial class DebugBot : Bot
 	}
 
 	[ConCmd.Admin( "bot_reset", Help = "Resets bot to default settings." )]
-	public static void DoBotReset()
+	public static void BotReset()
 	{
 		Wander = false;
 		MimicHost = false;
@@ -53,7 +53,7 @@ public partial class DebugBot : Bot
 	}
 
 	[ConCmd.Admin( "bot_kill", Help = "Kills bot by name if provided, else kills all bots." )]
-	public static void DoBotKill( string name = "" )
+	public static void BotKill( string name = "" )
 	{
 		if ( string.IsNullOrEmpty( name ) )
 		{
@@ -75,7 +75,7 @@ public partial class DebugBot : Bot
 	}
 
 	[ConCmd.Admin( "bot_kick", Help = "Kicks all bots." )]
-	public static void DoBotKick()
+	public static void BotKick()
 	{
 		foreach ( var b in All.ToArray() )
 			b.Client.Kick();

--- a/code/Other/DebugBot.cs
+++ b/code/Other/DebugBot.cs
@@ -13,7 +13,7 @@ public partial class DebugBot : Bot
 	public Player Pawn;
 
 	/// <summary>
-	/// The host Player.
+	/// The host Player who spawned this bot.
 	/// </summary>
 	public Player Target;
 

--- a/code/Other/DebugBot.cs
+++ b/code/Other/DebugBot.cs
@@ -1,0 +1,119 @@
+#if DEBUG
+using Sandbox;
+using Sandbox.Internal;
+using System.Linq;
+
+namespace TTT;
+
+public partial class DebugBot : Bot
+{
+	/// <summary>
+	/// The Player pawn this bot controls.
+	/// </summary>
+	public Player Pawn;
+
+	/// <summary>
+	/// The host Player.
+	/// </summary>
+	public Player Target;
+
+	public static bool Aimbot;
+	public static bool MimicHost;
+	public static bool Wander;
+
+	[ConVar.Replicated( "bot_debug" )]
+	public static bool DrawDebug { get; set; }
+
+	[ConCmd.Admin( "bot_aimbot", Help = "Locks the bot's aim to the player." )]
+	public static void ToggleBotAimbot()
+	{
+		Aimbot = !Aimbot;
+	}
+
+	[ConCmd.Admin( "bot_mimic", Help = "Makes the bot mimic the host client's inputs." )]
+	public static void ToggleMimicHost()
+	{
+		MimicHost = !MimicHost;
+		Wander = false;
+	}
+
+	[ConCmd.Admin( "bot_wander", Help = "Makes the bot randomly press move buttons." )]
+	public static void ToggleWander()
+	{
+		Wander = !Wander;
+		MimicHost = false;
+	}
+
+	[ConCmd.Admin( "bot_reset", Help = "Resets bot to default settings." )]
+	public static void DoBotReset()
+	{
+		Wander = false;
+		MimicHost = false;
+		Aimbot = false;
+	}
+
+	[ConCmd.Admin( "bot_kill", Help = "Kills bot by name if provided, else kills all bots." )]
+	public static void DoBotKill( string name = "" )
+	{
+		if ( string.IsNullOrEmpty( name ) )
+		{
+			foreach ( var b in All.ToArray() )
+			{
+				if ( b.Client.Pawn is Entity ent )
+					ent.OnKilled();
+			}
+
+			return;
+		}
+
+		var nameLower = name.ToLower();
+		foreach ( var b in All.ToArray() )
+		{
+			if ( b.Client.Name.ToLower() == nameLower && b.Client.Pawn is Entity ent )
+				ent.OnKilled();
+		}
+	}
+
+	[ConCmd.Admin( "bot_kick", Help = "Kicks all bots." )]
+	public static void DoBotKick()
+	{
+		foreach ( var b in All.ToArray() )
+			b.Client.Kick();
+	}
+
+	[ConCmd.Admin( "bot_add" )]
+	public static void AddBot()
+	{
+		var pawn = ConsoleSystem.Caller.Pawn;
+		if ( pawn is not Player ply )
+			return;
+
+		var b = new DebugBot();
+		b.Target = ply;
+		b.Pawn = b.Client.Pawn as Player;
+	}
+
+	public override void BuildInput()
+	{
+		Pawn.InputDirection = Vector3.Zero;
+
+		if ( DrawDebug )
+		{
+			DebugOverlay.Axis( Pawn.EyePosition, Pawn.EyeRotation, 24 );
+			DebugOverlay.Axis( Pawn.Position, Pawn.Rotation, 32 );
+		}
+
+		if ( Wander )
+			Pawn.InputDirection = Vector3.Random * 2f;
+
+		if ( MimicHost )
+		{
+			Input.CopyLastInput( Target.Client );
+			foreach ( var item in from p in GlobalGameNamespace.TypeLibrary.GetPropertyDescriptions( Client.Pawn )
+								  where p.HasAttribute<ClientInputAttribute>()
+								  select p )
+				item.SetValue( Client.Pawn, item.GetValue( Target ) );
+		}
+	}
+}
+#endif


### PR DESCRIPTION
Surrounded by #DEBUG preprocessor.

Adds a bot that makes debugging a bit easier than the standard s&box MimicBot. This bot can be toggled to mimic or wander vaguely randomly. Includes functionality for killing individual bots and kicking all bots. (You can already kick individual clients by name in s&box.) 

I originally included functionality for making all the bots attack and for aimbotting the player from my gamemode. I could add this back if you want.