### PR TITLE
Fix: Rifle zoom sensitivity feels bad

### DIFF
--- a/code/Player/Cameras/FirstPersonCamera.cs
+++ b/code/Player/Cameras/FirstPersonCamera.cs
@@ -33,7 +33,7 @@ public class FirstPersonCamera : CameraMode
 		var target = UI.Hud.DisplayedPlayer;
 
 		Camera.Position = target.EyePosition;
-		Camera.Rotation = !target.IsLocalPawn ? Rotation.Slerp( Camera.Rotation, target.EyeRotation, Time.Delta * 20f ) : target.EyeRotation;
+		Camera.Rotation = !target.IsLocalPawn ? Rotation.Slerp( Camera.Rotation, target.EyeRotation, Time.Delta * 20f ) : target.ViewAngles.ToRotation();
 		Camera.FirstPersonViewer = target;
 
 		// TODO: We need some way to override the FieldOfView from a carriable.


### PR DESCRIPTION
When zoomed in with the scout, your view would only turn one step for every two steps registered by the mouse. This made sniping feel like crap, and it also made it harder to aim at distant targets.

If you want to see the problem for yourself, paste this at the end of Player.FrameSimulate (a low mouse DPI makes it much easier to move one step at a time with the mouse):
var rotStr = $"{ViewAngles.pitch}, {ViewAngles.yaw}, {ViewAngles.roll}";
DebugOverlay.ScreenText( rotStr, 5 );
var camRotStr = $"{Camera.Rotation.Angles().pitch}, {Camera.Rotation.Angles().yaw}, {Camera.Rotation.Angles().roll}";
DebugOverlay.ScreenText( camRotStr, 6 );